### PR TITLE
Removed redundant ON_CREATE_DB ENV line

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -23,8 +23,7 @@ ENV MYSQL_USER=admin \
     REPLICATION_MASTER=**False** \
     REPLICATION_SLAVE=**False** \
     REPLICATION_USER=replica \
-    REPLICATION_PASS=replica \
-    ON_CREATE_DB=**False**
+    REPLICATION_PASS=replica
 
 # Add VOLUMEs to allow backup of config and databases
 VOLUME  ["/etc/mysql", "/var/lib/mysql"]


### PR DESCRIPTION
Is there some reason that was there? It looked unintentional.