### PR TITLE
Custom character set (and set default to utf8mb4)

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -19,6 +19,8 @@ ADD run.sh /run.sh
 
 ENV MYSQL_USER=admin \
     MYSQL_PASS=**Random** \
+    MYSQL_CHARACTER_SET=utf8mb4 \
+    MYSQL_COLLATION=utf8mb4_unicode_ci \
     ON_CREATE_DB=**False** \
     REPLICATION_MASTER=**False** \
     REPLICATION_SLAVE=**False** \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER Fernando Mayo <fernando@tutum.co>, Feng Honglin <hfeng@tutum.co>
 
 # Add MySQL configuration
 ADD my.cnf /etc/mysql/conf.d/my.cnf
-ADD mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf
 
 RUN apt-get update && \
     apt-get -yq install mysql-server-5.5 pwgen && \
@@ -12,6 +11,9 @@ RUN apt-get update && \
     if [ ! -f /usr/share/mysql/my-default.cnf ] ; then cp /etc/mysql/my.cnf /usr/share/mysql/my-default.cnf; fi && \
     mysql_install_db > /dev/null 2>&1 && \
     touch /var/lib/mysql/.EMPTY_DB
+
+# Add MySQL charset configuration
+ADD mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf
 
 # Add MySQL scripts
 ADD import_sql.sh /import_sql.sh

--- a/5.5/mysqld_charset.cnf
+++ b/5.5/mysqld_charset.cnf
@@ -1,7 +1,7 @@
 [mysqld]
-character_set_server=utf8
-character_set_filesystem=utf8
-collation-server=utf8_general_ci
-init-connect='SET NAMES utf8'
-init_connect='SET collation_connection = utf8_general_ci'
+character_set_server=MYSQL_CHARACTER_SET
+character_set_filesystem=MYSQL_CHARACTER_SET
+collation-server=MYSQL_COLLATION
+init-connect='SET NAMES MYSQL_CHARACTER_SET'
+init_connect='SET collation_connection = MYSQL_COLLATION'
 skip-character-set-client-handshake

--- a/5.5/mysqld_charset.cnf
+++ b/5.5/mysqld_charset.cnf
@@ -1,6 +1,5 @@
 [mysqld]
 character_set_server=MYSQL_CHARACTER_SET
-character_set_filesystem=MYSQL_CHARACTER_SET
 collation-server=MYSQL_COLLATION
 init-connect='SET NAMES MYSQL_CHARACTER_SET'
 init_connect='SET collation_connection = MYSQL_COLLATION'

--- a/5.5/run.sh
+++ b/5.5/run.sh
@@ -6,10 +6,15 @@ set -e
 VOLUME_HOME="/var/lib/mysql"
 CONF_FILE="/etc/mysql/conf.d/my.cnf"
 LOG="/var/log/mysql/error.log"
+CHARSET_CONF_FILE="/etc/mysql/conf.d/mysqld_charset.cnf"
 
 # Set permission of config file
 chmod 644 ${CONF_FILE}
-chmod 644 /etc/mysql/conf.d/mysqld_charset.cnf
+
+# Update charset file and set permission
+sed -i "s/MYSQL_CHARACTER_SET/${MYSQL_CHARACTER_SET}/" ${CHARSET_CONF_FILE}
+sed -i "s/MYSQL_COLLATION/${MYSQL_COLLATION}/" ${CHARSET_CONF_FILE}
+chmod 644 ${CHARSET_CONF_FILE}
 
 StartMySQL ()
 {

--- a/5.5/run.sh
+++ b/5.5/run.sh
@@ -31,6 +31,9 @@ StartMySQL ()
         sleep 1
         mysql -uroot -e "status" > /dev/null 2>&1 && break
     done
+
+    # Remove non-exist plugin
+    mysql -uroot -e "DELETE FROM mysql.plugin WHERE name IN ('innodb', 'federated', 'blackhole', 'archive');"
 }
 
 CreateMySQLUser()

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER Fernando Mayo <fernando@tutum.co>, Feng Honglin <hfeng@tutum.co>
 
 # Add MySQL configuration
 ADD my.cnf /etc/mysql/conf.d/my.cnf
-ADD mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf
 
 RUN apt-get update && \
     apt-get -yq install mysql-server-5.6 pwgen && \
@@ -12,6 +11,9 @@ RUN apt-get update && \
     if [ ! -f /usr/share/mysql/my-default.cnf ] ; then cp /etc/mysql/my.cnf /usr/share/mysql/my-default.cnf; fi && \
     mysql_install_db > /dev/null 2>&1 && \
     touch /var/lib/mysql/.EMPTY_DB
+
+# Add MySQL charset configuration
+ADD mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf
 
 # Add MySQL scripts
 ADD import_sql.sh /import_sql.sh

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -19,6 +19,8 @@ ADD run.sh /run.sh
 
 ENV MYSQL_USER=admin \
     MYSQL_PASS=**Random** \
+    MYSQL_CHARACTER_SET=utf8mb4 \
+    MYSQL_COLLATION=utf8mb4_unicode_ci \
     ON_CREATE_DB=**False** \
     REPLICATION_MASTER=**False** \
     REPLICATION_SLAVE=**False** \

--- a/5.6/mysqld_charset.cnf
+++ b/5.6/mysqld_charset.cnf
@@ -1,7 +1,7 @@
 [mysqld]
-character_set_server=utf8
-character_set_filesystem=utf8
-collation-server=utf8_general_ci
-init-connect='SET NAMES utf8'
-init_connect='SET collation_connection = utf8_general_ci'
+character_set_server=MYSQL_CHARACTER_SET
+character_set_filesystem=MYSQL_CHARACTER_SET
+collation-server=MYSQL_COLLATION
+init-connect='SET NAMES MYSQL_CHARACTER_SET'
+init_connect='SET collation_connection = MYSQL_COLLATION'
 skip-character-set-client-handshake

--- a/5.6/mysqld_charset.cnf
+++ b/5.6/mysqld_charset.cnf
@@ -1,6 +1,5 @@
 [mysqld]
 character_set_server=MYSQL_CHARACTER_SET
-character_set_filesystem=MYSQL_CHARACTER_SET
 collation-server=MYSQL_COLLATION
 init-connect='SET NAMES MYSQL_CHARACTER_SET'
 init_connect='SET collation_connection = MYSQL_COLLATION'

--- a/5.6/run.sh
+++ b/5.6/run.sh
@@ -6,10 +6,15 @@ set -e
 VOLUME_HOME="/var/lib/mysql"
 CONF_FILE="/etc/mysql/conf.d/my.cnf"
 LOG="/var/log/mysql/error.log"
+CHARSET_CONF_FILE="/etc/mysql/conf.d/mysqld_charset.cnf"
 
 # Set permission of config file
 chmod 644 ${CONF_FILE}
-chmod 644 /etc/mysql/conf.d/mysqld_charset.cnf
+
+# Update charset file and set permission
+sed -i "s/MYSQL_CHARACTER_SET/${MYSQL_CHARACTER_SET}/" ${CHARSET_CONF_FILE}
+sed -i "s/MYSQL_COLLATION/${MYSQL_COLLATION}/" ${CHARSET_CONF_FILE}
+chmod 644 ${CHARSET_CONF_FILE}
 
 StartMySQL ()
 {

--- a/5.6/run.sh
+++ b/5.6/run.sh
@@ -31,6 +31,9 @@ StartMySQL ()
         sleep 1
         mysql -uroot -e "status" > /dev/null 2>&1 && break
     done
+
+    # Remove non-exist plugin
+    mysql -uroot -e "DELETE FROM mysql.plugin WHERE name IN ('innodb', 'federated', 'blackhole', 'archive');"
 }
 
 CreateMySQLUser()

--- a/README.md
+++ b/README.md
@@ -158,12 +158,30 @@ Examples:
 
 Now you can access port `3306` and `3307` for the master/slave MySQL.
 
+
+Character set and collation
+---------------------------
+To change MySQL character set and collation, please set environment variable `MYSQL_CHARACTER_SET` and `MYSQL_COLLATION` to any supported value by MySQL server. By default, `utf8mb4` and `utf8mb4_unicode_ci` are used in order to support 4-bytes unicode character (including emoji, astral symbol, etc.).
+
+To ensure to use `utf8mb4` and `utf8mb4_general_ci`:
+
+        docker run -d -e MYSQL_CHARACTER_SET=utf8mb4 -e MYSQL_COLLATION=utf8mb4_general_ci -p 3306:3306 --name mysql tutum/mysql
+
+To use `utf8` and `utf8_general_ci`:
+
+        docker run -d -e MYSQL_CHARACTER_SET=utf8 -e MYSQL_COLLATION=utf8_general_ci -p 3306:3306 --name mysql tutum/mysql
+
+
 Environment variables
 ---------------------
 
-`MYSQL_USER`: Set a specific username for the admin account (default 'admin').
+`MYSQL_USER`: Set a specific username for the admin account (default `admin`).
 
 `MYSQL_PASS`: Set a specific password for the admin account.
+
+`MYSQL_CHARACTER_SET`: Set a specific character encoding set (default `utf8mb4`)
+
+`MYSQL_COLLATION`: Set a specific collation (default `utf8mb4_unicode_ci`)
 
 `STARTUP_SQL`: Defines one or more SQL scripts separated by spaces to initialize the database. Note that the scripts must be inside the container, so you may need to mount them.
 


### PR DESCRIPTION
By default, the current docker image supports `utf8` charset. Unfortunately, [`utf8`](https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8.html) in MySQL is not real UTF-8. `utf8` is only support up to 3-bytes per character. The actual UTF-8 is up to 4-bytes per character (e.g: emoji, astral symbol, wider CJK characters, etc.). To full support UTF-8, we can use [`utf8mb4`](https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8mb4.html) charset.

Using the current images, I can't force the MySQL to use `utf8mb4` because there is a config to force using `utf8` which is not compatible with `utf8mb4` (it made my apps broken ☹). `utf8mb4` is [backward compatible](https://mathiasbynens.be/notes/mysql-utf8mb4) with `utf8`.