### PR TITLE
Improvements to shell and Dockerfile scripts.

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:trusty
 MAINTAINER Fernando Mayo <fernando@tutum.co>, Feng Honglin <hfeng@tutum.co>
 
 # Add MySQL configuration
-ADD my.cnf /etc/mysql/conf.d/my.cnf
-ADD mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf
+COPY my.cnf /etc/mysql/conf.d/my.cnf
+COPY mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf
 
 RUN apt-get update && \
     apt-get -yq install mysql-server-5.5 pwgen && \
@@ -14,8 +14,8 @@ RUN apt-get update && \
     touch /var/lib/mysql/.EMPTY_DB
 
 # Add MySQL scripts
-ADD import_sql.sh /import_sql.sh
-ADD run.sh /run.sh
+COPY import_sql.sh /import_sql.sh
+COPY run.sh /run.sh
 
 ENV MYSQL_USER=admin \
     MYSQL_PASS=**Random** \

--- a/5.5/import_sql.sh
+++ b/5.5/import_sql.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ $# -ne 3 ]]; then
-	echo "Usage: $0 <username> <password> </path/to/sql_file.sql>"
-	exit 1
+    echo "Usage: $0 <username> <password> </path/to/sql_file.sql>"
+    exit 1
 fi
 
 echo "=> Starting MySQL Server"
@@ -14,7 +14,7 @@ while [[ RET -ne 0 ]]; do
     echo "=> Waiting for confirmation of MySQL service startup"
     sleep 5
     mysql -u"$1" -p"$2" -e "status" > /dev/null 2>&1
-RET=$?
+    RET=$?
 done
 
 echo "   Started with PID ${PID}"

--- a/5.5/run.sh
+++ b/5.5/run.sh
@@ -30,25 +30,25 @@ StartMySQL ()
 
 CreateMySQLUser()
 {
-	if [ "$MYSQL_PASS" = "**Random**" ]; then
-	    unset MYSQL_PASS
-	fi
+    if [ "$MYSQL_PASS" = "**Random**" ]; then
+        unset MYSQL_PASS
+    fi
 
-	PASS=${MYSQL_PASS:-$(pwgen -s 12 1)}
-	_word=$( [ ${MYSQL_PASS} ] && echo "preset" || echo "random" )
-	echo "=> Creating MySQL user ${MYSQL_USER} with ${_word} password"
+    PASS=${MYSQL_PASS:-$(pwgen -s 12 1)}
+    _word=$( [ ${MYSQL_PASS} ] && echo "preset" || echo "random" )
+    echo "=> Creating MySQL user ${MYSQL_USER} with ${_word} password"
 
-	mysql -uroot -e "CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '$PASS'"
-	mysql -uroot -e "GRANT ALL PRIVILEGES ON *.* TO '${MYSQL_USER}'@'%' WITH GRANT OPTION"
-	echo "=> Done!"
-	echo "========================================================================"
-	echo "You can now connect to this MySQL Server using:"
-	echo ""
-	echo "    mysql -u$MYSQL_USER -p$PASS -h<host> -P<port>"
-	echo ""
-	echo "Please remember to change the above password as soon as possible!"
-	echo "MySQL user 'root' has no password but only allows local connections"
-	echo "========================================================================"
+    mysql -uroot -e "CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '$PASS'"
+    mysql -uroot -e "GRANT ALL PRIVILEGES ON *.* TO '${MYSQL_USER}'@'%' WITH GRANT OPTION"
+    echo "=> Done!"
+    echo "========================================================================"
+    echo "You can now connect to this MySQL Server using:"
+    echo ""
+    echo "    mysql -u$MYSQL_USER -p$PASS -h<host> -P<port>"
+    echo ""
+    echo "Please remember to change the above password as soon as possible!"
+    echo "MySQL user 'root' has no password but only allows local connections"
+    echo "========================================================================"
 }
 
 OnCreateDB()
@@ -65,7 +65,7 @@ OnCreateDB()
 ImportSql()
 {
     for FILE in ${STARTUP_SQL}; do
-	    echo "=> Importing SQL file ${FILE}"
+        echo "=> Importing SQL file ${FILE}"
         if [ "$ON_CREATE_DB" ]; then
             mysql -uroot "$ON_CREATE_DB" < "${FILE}"
         else

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:trusty
 MAINTAINER Fernando Mayo <fernando@tutum.co>, Feng Honglin <hfeng@tutum.co>
 
 # Add MySQL configuration
-ADD my.cnf /etc/mysql/conf.d/my.cnf
-ADD mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf
+COPY my.cnf /etc/mysql/conf.d/my.cnf
+COPY mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf
 
 RUN apt-get update && \
     apt-get -yq install mysql-server-5.6 pwgen && \
@@ -14,8 +14,8 @@ RUN apt-get update && \
     touch /var/lib/mysql/.EMPTY_DB
 
 # Add MySQL scripts
-ADD import_sql.sh /import_sql.sh
-ADD run.sh /run.sh
+COPY import_sql.sh /import_sql.sh
+COPY run.sh /run.sh
 
 ENV MYSQL_USER=admin \
     MYSQL_PASS=**Random** \

--- a/5.6/import_sql.sh
+++ b/5.6/import_sql.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ $# -ne 3 ]]; then
-	echo "Usage: $0 <username> <password> </path/to/sql_file.sql>"
-	exit 1
+    echo "Usage: $0 <username> <password> </path/to/sql_file.sql>"
+    exit 1
 fi
 
 echo "=> Starting MySQL Server"
@@ -10,11 +10,11 @@ echo "=> Starting MySQL Server"
 PID=$!
 
 RET=1
-while [[ RET -ne 0 ]]; do
+while [[ $RET -ne 0 ]]; do
     echo "=> Waiting for confirmation of MySQL service startup"
     sleep 5
     mysql -u"$1" -p"$2" -e "status" > /dev/null 2>&1
-RET=$?
+    RET=$?
 done
 
 echo "   Started with PID ${PID}"

--- a/5.6/run.sh
+++ b/5.6/run.sh
@@ -30,25 +30,25 @@ StartMySQL ()
 
 CreateMySQLUser()
 {
-	if [ "$MYSQL_PASS" = "**Random**" ]; then
-	    unset MYSQL_PASS
-	fi
+    if [ "$MYSQL_PASS" = "**Random**" ]; then
+        unset MYSQL_PASS
+    fi
 
-	PASS=${MYSQL_PASS:-$(pwgen -s 12 1)}
-	_word=$( [ ${MYSQL_PASS} ] && echo "preset" || echo "random" )
-	echo "=> Creating MySQL user ${MYSQL_USER} with ${_word} password"
+    PASS=${MYSQL_PASS:-$(pwgen -s 12 1)}
+    _word=$( [ ${MYSQL_PASS} ] && echo "preset" || echo "random" )
+    echo "=> Creating MySQL user ${MYSQL_USER} with ${_word} password"
 
-	mysql -uroot -e "CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '$PASS'"
-	mysql -uroot -e "GRANT ALL PRIVILEGES ON *.* TO '${MYSQL_USER}'@'%' WITH GRANT OPTION"
-	echo "=> Done!"
-	echo "========================================================================"
-	echo "You can now connect to this MySQL Server using:"
-	echo ""
-	echo "    mysql -u$MYSQL_USER -p$PASS -h<host> -P<port>"
-	echo ""
-	echo "Please remember to change the above password as soon as possible!"
-	echo "MySQL user 'root' has no password but only allows local connections"
-	echo "========================================================================"
+    mysql -uroot -e "CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '$PASS'"
+    mysql -uroot -e "GRANT ALL PRIVILEGES ON *.* TO '${MYSQL_USER}'@'%' WITH GRANT OPTION"
+    echo "=> Done!"
+    echo "========================================================================"
+    echo "You can now connect to this MySQL Server using:"
+    echo ""
+    echo "    mysql -u$MYSQL_USER -p$PASS -h<host> -P<port>"
+    echo ""
+    echo "Please remember to change the above password as soon as possible!"
+    echo "MySQL user 'root' has no password but only allows local connections"
+    echo "========================================================================"
 }
 
 OnCreateDB()
@@ -65,7 +65,7 @@ OnCreateDB()
 ImportSql()
 {
     for FILE in ${STARTUP_SQL}; do
-	    echo "=> Importing SQL file ${FILE}"
+        echo "=> Importing SQL file ${FILE}"
         if [ "$ON_CREATE_DB" ]; then
             mysql -uroot "$ON_CREATE_DB" < "${FILE}"
         else

--- a/test.sh
+++ b/test.sh
@@ -19,10 +19,10 @@ mysql -uuser -ptest -h127.0.0.1 -P13308 -e "show slave status\G;" | grep "Slave_
 
 echo "=> Testing volume on mysql 5.5"
 mkdir vol55
-docker run --name mysql55.1 -d -p 13309:3306 -e MYSQL_USER="user" -e MYSQL_PASS="test" -v $(pwd)/vol55:/var/lib/mysql mysql-5.5; sleep 10
+docker run --name mysql55.1 -d -p 13309:3306 -e MYSQL_USER="user" -e MYSQL_PASS="test" -v "$(pwd)/vol55":/var/lib/mysql mysql-5.5; sleep 10
 mysqladmin -uuser -ptest -h127.0.0.1 -P13309 ping | grep -c "mysqld is alive"
 docker stop mysql55.1
-docker run  -d -p 13310:3306 -v $(pwd)/vol55:/var/lib/mysql mysql-5.5; sleep 10
+docker run  -d -p 13310:3306 -v "$(pwd)/vol55":/var/lib/mysql mysql-5.5; sleep 10
 mysqladmin -uuser -ptest -h127.0.0.1 -P13310 ping | grep -c "mysqld is alive"
 
 echo "=> Building mysql 5.6 image"
@@ -42,10 +42,10 @@ mysql -uuser -ptest -h127.0.0.1 -P23308 -e "show slave status\G;" | grep "Slave_
 
 echo "=> Testing volume on mysql 5.6"
 mkdir vol56
-docker run --name mysql56.1 -d -p 23309:3306 -e MYSQL_USER="user" -e MYSQL_PASS="test" -v $(pwd)/vol56:/var/lib/mysql mysql-5.6; sleep 10
+docker run --name mysql56.1 -d -p 23309:3306 -e MYSQL_USER="user" -e MYSQL_PASS="test" -v "$(pwd)/vol56":/var/lib/mysql mysql-5.6; sleep 10
 mysqladmin -uuser -ptest -h127.0.0.1 -P23309 ping | grep -c "mysqld is alive"
 docker stop mysql56.1
-docker run  -d -p 23310:3306 -v $(pwd)/vol56:/var/lib/mysql mysql-5.6; sleep 10
+docker run  -d -p 23310:3306 -v "$(pwd)/vol56":/var/lib/mysql mysql-5.6; sleep 10
 mysqladmin -uuser -ptest -h127.0.0.1 -P23310 ping | grep -c "mysqld is alive"
 
 echo "=>Done"


### PR DESCRIPTION
- `test.sh`: Adds quotes to prevent word splitting.
- `5.*/Dockerfile`: Prefer `COPY` over `ADD`.
  See: https://docs.docker.com/engine/articles/dockerfile_best-practices/
- `5.*/import_sql.sh`: Adds missing $. I admit I don't know why it works
  without the $ there, but it's unnerving, and shellcheck complains that
  "This expression is constant. Did you forget the $ on a variable?"
- Some scripts have a mixture of tabs and spaces for indention. Spaces
  are the more common style. Untabifies those scripts.